### PR TITLE
Update README to remove USB4000 from spectrometers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PySpecTrace v.1.0.0 has been tested and working seamlessly with these commercial
 ### Ocean optics:
 - Maya PRO2000
 - HR 4000CG-UV-NIR
-- USB4000
+
 ### Avantes:
 - AvaSpec-ULS4096CL-EVO
 ### CNI:


### PR DESCRIPTION
Removed USB4000 from the list of tested spectrometers.